### PR TITLE
Update pt_br.json

### DIFF
--- a/src/main/resources/assets/bayou_blues/lang/pt_br.json
+++ b/src/main/resources/assets/bayou_blues/lang/pt_br.json
@@ -31,7 +31,7 @@
 
   "item.bayou_blues.cypress_boat": "Bote de cipreste",
 
-  "block.bayou_blues.hanging_cypress_leaves": "Folhas de cipreste penduradas",
+  "block.bayou_blues.hanging_cypress_leaves": "Folhas de cipreste suspensas",
 
   "block.bayou_blues.cypress_knee": "Joelho de cipreste",
   "block.bayou_blues.large_cypress_knee": "Joelho de cipreste grande",
@@ -45,7 +45,7 @@
   "block.bayou_blues.cypress_branch": "Galho de cipreste",
   "block.bayou_blues.gooseberry_sack": "Saco de groselhas",
 
-  "item.bayou_blues.honey_glazed_gooseberries": "Groselhas glaceadas",
+  "item.bayou_blues.honey_glazed_gooseberries": "Groselhas glaceadas com mel",
   "item.bayou_blues.gooseberry_jam": "Geleia de groselha",
   "item.bayou_blues.gooseberry_jam_cookie": "Biscoito de geleia de groselha",
 
@@ -58,31 +58,31 @@
 
 
   "_comment3": "Lily Flowers",
-  "block.bayou_blues.blue_lily": "Lírio azul",
-  "block.bayou_blues.light_gray_lily": "Lírio cinza-claro",
-  "block.bayou_blues.cyan_lily": "Lírio ciano",
-  "block.bayou_blues.light_blue_lily": "Lírio azul-claro",
-  "block.bayou_blues.magenta_lily": "Lírio magenta",
-  "block.bayou_blues.pink_lily": "Lírio rosa",
-  "block.bayou_blues.purple_lily": "Lírio roxo",
-  "block.bayou_blues.white_lily": "Lírio branco",
+  "block.bayou_blues.blue_lily": "Nenúfar azul",
+  "block.bayou_blues.light_gray_lily": "Nenúfar cinza-claro",
+  "block.bayou_blues.cyan_lily": "Nenúfar ciano",
+  "block.bayou_blues.light_blue_lily": "Nenúfar azul-claro",
+  "block.bayou_blues.magenta_lily": "Nenúfar magenta",
+  "block.bayou_blues.pink_lily": "Nenúfar rosa",
+  "block.bayou_blues.purple_lily": "Nenúfar roxo",
+  "block.bayou_blues.white_lily": "Nenúfar branco",
 
-  "item.bayou_blues.blue_lily": "Lírio azul",
-  "item.bayou_blues.light_gray_lily": "Lírio cinza-claro",
-  "item.bayou_blues.cyan_lily": "Lírio ciano",
-  "item.bayou_blues.light_blue_lily": "Lírio azul-claro",
-  "item.bayou_blues.magenta_lily": "Lírio magenta",
-  "item.bayou_blues.pink_lily": "Lírio rosa",
-  "item.bayou_blues.purple_lily": "Lírio roxo",
-  "item.bayou_blues.white_lily": "Lírio branco",
+  "item.bayou_blues.blue_lily": "Nenúfar azul",
+  "item.bayou_blues.light_gray_lily": "Nenúfar cinza-claro",
+  "item.bayou_blues.cyan_lily": "Nenúfar ciano",
+  "item.bayou_blues.light_blue_lily": "Nenúfar azul-claro",
+  "item.bayou_blues.magenta_lily": "Nenúfar magenta",
+  "item.bayou_blues.pink_lily": "Nenúfar rosa",
+  "item.bayou_blues.purple_lily": "Nenúfar roxo",
+  "item.bayou_blues.white_lily": "Nenúfar branco",
 
 
   "_comment4": "Other Vegetation",
-  "block.bayou_blues.algae": "Algas",
-  "block.bayou_blues.algae_thatch": "Palha de algas",
-  "block.bayou_blues.algae_thatch_slab": "Laje de palha de algas",
-  "block.bayou_blues.algae_thatch_stairs": "Escadas de palha de algas",
-  "block.bayou_blues.algae_thatch_vertical_slab": "Laje vertical de palha de algas",
+  "block.bayou_blues.algae": "Tapete algal",
+  "block.bayou_blues.algae_thatch": "Revestimento algal",
+  "block.bayou_blues.algae_thatch_slab": "Laje de revestimento algal",
+  "block.bayou_blues.algae_thatch_stairs": "Escadas de revestimento algal",
+  "block.bayou_blues.algae_thatch_vertical_slab": "Laje vertical de revestimento algal",
 
   "block.bayou_blues.beard_moss_block": "Bloco de barba-de-velho",
   "block.bayou_blues.beard_moss": "Barba-de-velho",


### PR DESCRIPTION
- Changed algae translations to better differ them from kelp translations (Kelp = Alga; and Algae - Algas. It was very confusing, so I've changed them)
- Changed thatch translations. Previously, they were translated as "palha", wich means "straw". Even though the translation is technicaly right, it is not adequate with the context;
- Changed lily translations to differ them from land lilies, while still faithful to the original names;
- Changed honey glazed gooseberies translations to better describe that they are made with honey;
- Changed hanging cypress leaves translation from "Folhas de cipreste penduradas" to "Folhas de cipreste suspensas".